### PR TITLE
Add WURCS Support

### DIFF
--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(
         ${WRK_DIR}/src/cpp/sails-dot.cpp
         ${WRK_DIR}/src/cpp/sails-telemetry.cpp
         ${WRK_DIR}/src/cpp/sails-solvent.cpp
+        ${WRK_DIR}/src/cpp/sails-wurcs.cpp
 
         # Density
         ${WRK_DIR}/src/cpp/density/sails-density.cpp

--- a/package/_pyproject.toml
+++ b/package/_pyproject.toml
@@ -31,6 +31,7 @@ sails-snfg = "sails.snfg:run"
 sails-compare = "sails.compare:run"
 sails-find = "sails.find:run"
 sails-test = "sails.test:run"
+sails-wurcs = "sails.wurcs:run"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -39,6 +39,7 @@ sails-snfg = "sails.snfg:run"
 sails-compare = "sails.compare:run"
 sails-find = "sails.find:run"
 sails-test = "sails.test:run"
+sails-wurcs = "sails.wurcs:run"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core

--- a/package/src/bindings/python_sails.cpp
+++ b/package/src/bindings/python_sails.cpp
@@ -197,6 +197,8 @@ NB_MODULE(sails_module, m) {
           nb::overload_cast<gemmi::Structure &, gemmi::Grid<> &, int, std::string &, bool>(&o_mannosylate),
           "structure"_a, "grid"_a, "cycles"_a, "resource_dir"_a, "verbose"_a);
 
+    m.def("wurcs", &wurcs, "structure"_a, "chain"_a, "seqid"_a, "resource_dir"_a);
+
 
     m.def("test_snfg", &test);
 

--- a/package/src/bindings/python_sails.cpp
+++ b/package/src/bindings/python_sails.cpp
@@ -197,8 +197,9 @@ NB_MODULE(sails_module, m) {
           nb::overload_cast<gemmi::Structure &, gemmi::Grid<> &, int, std::string &, bool>(&o_mannosylate),
           "structure"_a, "grid"_a, "cycles"_a, "resource_dir"_a, "verbose"_a);
 
-    m.def("wurcs", &wurcs, "structure"_a, "chain"_a, "seqid"_a, "resource_dir"_a);
-
+    m.def("find_all_wurcs", &find_all_wurcs, "structure"_a, "resource_dir"_a);
+    m.def("find_wurcs", &find_wurcs, "structure"_a, "chain"_a, "seqid"_a,  "resource_dir"_a);
+    m.def("model_wurcs", &model_wurcs, "structure"_a, "wurcs"_a, "chain"_a, "seqid"_a, "resource_dir"_a);
 
     m.def("test_snfg", &test);
 

--- a/package/src/cpp/sails-glycan.cpp
+++ b/package/src/cpp/sails-glycan.cpp
@@ -102,6 +102,17 @@ void Sails::Glycan::dfs(Sugar *current_sugar, std::vector<Sugar *> &terminal_sug
     }
 }
 
+void Sails::Glycan::dfs_sites(Sugar *current_sugar, std::vector<Glycosite> &sites, int depth) {
+    const std::set<Sugar *> &sugar_set = adjacency_list[current_sugar];
+    current_sugar->depth = depth;
+    sites.push_back(current_sugar->site);
+
+    for (Sugar *sugar: sugar_set) {
+        sugar->depth = depth + 1;
+        dfs_sites(sugar, sites, depth + 1);
+    }
+}
+
 std::set<Sails::Glycosite> Sails::Glycan::operator-(const Glycan& glycan) {
     std::set<Glycosite> this_keys;
     std::transform(this->sugars.begin(), this->sugars.end(), std::inserter(this_keys, this_keys.end()),

--- a/package/src/cpp/sails-json.cpp
+++ b/package/src/cpp/sails-json.cpp
@@ -188,5 +188,7 @@ Sails::JSONLoader::extract_atom_set(simdjson::simdjson_result<simdjson::ondemand
         atom_sets.emplace_back(atom_set);
     }
 
-    return atom_sets;
-}
+    std::sort(atom_sets.begin(), atom_sets.end(), [](const Sails::AtomSet &a, const Sails::AtomSet &b) {
+        return a.identifier < b.identifier;
+    });
+    return atom_sets;}

--- a/package/src/cpp/sails-json.cpp
+++ b/package/src/cpp/sails-json.cpp
@@ -53,9 +53,8 @@ Sails::ResidueDatabase Sails::JSONLoader::load_residue_database() {
         std::string anomer = std::string(value[anomer_key].get_string().value());
         std::string wurcs_code = std::string(value[wurcs_code_key].get_string().value());
 
-        ResidueData data = {acceptors_sets, donor_sets, snfg_shape, snfg_colour, preferred_depths, anomer, wurcs_code};
         bool special = value[special_key].get_bool();
-        ResidueData data = {acceptors_sets, donor_sets, snfg_shape, snfg_colour, preferred_depths, anomer, special};
+        ResidueData data = {acceptors_sets, donor_sets, snfg_shape, snfg_colour, preferred_depths, anomer, wurcs_code, special};
         database.insert({name, data});
     }
 

--- a/package/src/cpp/sails-json.cpp
+++ b/package/src/cpp/sails-json.cpp
@@ -30,6 +30,7 @@ Sails::ResidueDatabase Sails::JSONLoader::load_residue_database() {
     const char *snfg_colour_key = "snfgColour";
     const char *preferred_depth_key = "preferredDepths";
     const char *anomer_key = "anomer";
+    const char *wurcs_code_key = "wurcsCode";
 
 
     ResidueDatabase database;
@@ -49,8 +50,9 @@ Sails::ResidueDatabase Sails::JSONLoader::load_residue_database() {
         }
 
         std::string anomer = std::string(value[anomer_key].get_string().value());
+        std::string wurcs_code = std::string(value[wurcs_code_key].get_string().value());
 
-        ResidueData data = {acceptors_sets, donor_sets, snfg_shape, snfg_colour, preferred_depths, anomer};
+        ResidueData data = {acceptors_sets, donor_sets, snfg_shape, snfg_colour, preferred_depths, anomer, wurcs_code};
         database.insert({name, data});
     }
 

--- a/package/src/cpp/sails-utils.cpp
+++ b/package/src/cpp/sails-utils.cpp
@@ -65,6 +65,15 @@ gemmi::Atom Sails::Utils::get_atom_from_glycosite(const Glycosite &site, const g
     return structure->models[site.model_idx].chains[site.chain_idx].residues[site.residue_idx].atoms[site.atom_idx];
 }
 
+std::optional<gemmi::Chain*> Sails::Utils::get_last_chain(gemmi::Structure *structure) {
+    if (structure->models[0].chains.empty()) { return std::nullopt; }
+    return &structure->models[0].chains[structure->models[0].chains.size()-1];
+}
+
+int Sails::Utils::get_last_chain_index(gemmi::Structure* structure) {
+    return structure->models[0].chains.empty() ? 0: structure->models[0].chains.size()-1;
+}
+
 std::string Sails::Utils::linkage_to_id(const Sails::LinkageData &data) {
     return data.donor + "-" + std::to_string(data.donor_number) + "," + std::to_string(data.acceptor_number) + "-" +
            data.acceptor;
@@ -74,14 +83,16 @@ void Sails::Utils::save_residues_to_file(std::vector<gemmi::Residue> residues, c
     gemmi::Structure structure;
     gemmi::Model model = gemmi::Model("A");
     gemmi::Chain chain = gemmi::Chain("A");
-    chain.append_residues(std::move(residues));
+    for (auto& residue : residues) {
+        chain.residues.push_back(residue);
+    }
     model.chains = {chain};
     structure.models = {model};
 
-    std::ofstream file;
-    file.open(path);
-    gemmi::write_pdb(structure, file);
-    file.close();
+    std::ofstream of;
+    of.open(path);
+    write_cif_to_stream(of, make_mmcif_document(structure));
+    of.close();
 }
 
 void Sails::Utils::save_grid_to_file(const gemmi::Grid<> &grid, const std::string &path) {

--- a/package/src/cpp/sails-utils.cpp
+++ b/package/src/cpp/sails-utils.cpp
@@ -121,3 +121,13 @@ bool Sails::Utils::file_exists(const std::string &path) {
     f.close();
     return good;
 }
+
+std::vector<std::string> Sails::Utils::split(const std::string &string, char delimiter) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream token_stream(string);
+    while (std::getline(token_stream, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}

--- a/package/src/cpp/sails-wurcs.cpp
+++ b/package/src/cpp/sails-wurcs.cpp
@@ -7,8 +7,7 @@
 
 // WURCS WRITING
 
-std::string Sails::WURCS::generate_wurcs(Sails::Glycan *glycan, Sails::ResidueDatabase& residue_database) {
-
+std::string Sails::WURCS::generate_wurcs(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
     std::stringstream wurcs;
 
     wurcs << get_wurcs_header() << get_section_delimiter();
@@ -29,17 +28,16 @@ std::string Sails::WURCS::get_unit_count(Sails::Glycan *glycan) {
 }
 
 std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
-
     std::vector<std::string> unique_sugars = glycan->get_unique_sugar_names();
 
     std::stringstream unique_residues;
-    for (auto& sugar: unique_sugars) {
+    for (auto &sugar: unique_sugars) {
         if (residue_database.find(sugar) == residue_database.end()) {
             unique_residues << "[" << sugar << "]";
             continue;
         }
         std::optional<std::string> wurcs = residue_database[sugar].wurcs_code;
-        if (!wurcs.has_value()) {continue;} // an ASN, TRP, etc. would not have a WURCS code
+        if (!wurcs.has_value()) { continue; } // an ASN, TRP, etc. would not have a WURCS code
 
         unique_residues << "[" << wurcs.value() << "]";
     }
@@ -48,7 +46,6 @@ std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::
 }
 
 std::string Sails::WURCS::get_residue_order(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
-
     std::vector<int> order = calculate_residue_order(glycan, residue_database);
 
     std::stringstream residue_order;
@@ -64,7 +61,6 @@ std::string Sails::WURCS::get_residue_order(Sails::Glycan *glycan, Sails::Residu
 }
 
 std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
-
     std::vector<int> order = calculate_residue_order(glycan, residue_database);
     auto sugar_sites = glycan->get_sugar_site_dfs_order();
     auto sugar_names = glycan->get_sugar_name_order();
@@ -81,7 +77,7 @@ std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDat
             continue;
         }
         std::optional<std::string> wurcs = residue_database[sugar_names[i]].wurcs_code;
-        if (!wurcs.has_value()) {continue;}
+        if (!wurcs.has_value()) { continue; }
 
         site_map[sugar_sites[i]] = alphabet[alphabet_count];
         alphabet_count++;
@@ -89,17 +85,17 @@ std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDat
 
     std::vector<std::string> linkage_order;
 
-    for (auto& site: sugar_sites) {
-        Sugar* sugar_ptr = sugars->at(site).get();
+    for (auto &site: sugar_sites) {
+        Sugar *sugar_ptr = sugars->at(site).get();
         if (adjacency_list->find(sugar_ptr) == adjacency_list->end()) {
             continue;
         }
 
-        std::set<Sugar*> linked_sugars = adjacency_list->at(sugar_ptr);
+        std::set<Sugar *> linked_sugars = adjacency_list->at(sugar_ptr);
 
-        std::map<int, Linkage*> linkages;
-        for (auto& linked_sugar: linked_sugars) {
-            Linkage* linkage = sugar_ptr->find_linkage(sugar_ptr, linked_sugar);
+        std::map<int, Linkage *> linkages;
+        for (auto &linked_sugar: linked_sugars) {
+            Linkage *linkage = sugar_ptr->find_linkage(sugar_ptr, linked_sugar);
 
             if (site_map.find(linkage->donor_sugar->site) == site_map.end()) {
                 continue;
@@ -113,7 +109,7 @@ std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDat
             linkages[linkage_donor_number] = linkage;
         }
 
-        for (auto& [number, linkage]: linkages) {
+        for (auto &[number, linkage]: linkages) {
             std::stringstream linkage_string;
             linkage_string << site_map.at(linkage->donor_sugar->site) << number;
             linkage_string << "-";
@@ -125,7 +121,7 @@ std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDat
     std::stringstream linkage_stream;
     for (int i = 0; i < linkage_order.size(); i++) {
         linkage_stream << linkage_order[i];
-        if (i < linkage_order.size()-1) {
+        if (i < linkage_order.size() - 1) {
             linkage_stream << "_";
         }
     }
@@ -142,12 +138,12 @@ Sails::WURCS::calculate_residue_order(Sails::Glycan *glycan, Sails::ResidueDatab
     for (int i = 0; i < unique_sugars.size(); i++) {
         std::string unique_sugar = unique_sugars[i];
         std::optional<std::string> wurcs = residue_database[unique_sugar].wurcs_code;
-        if (!wurcs.has_value()) {continue;}
+        if (!wurcs.has_value()) { continue; }
         sugar_indices[unique_sugars[i]] = i;
     }
 
-    std::vector<int> order ;
-    for (const auto& name: sugar_order) {
+    std::vector<int> order;
+    for (const auto &name: sugar_order) {
         if (sugar_indices.find(name) == sugar_indices.end()) {
             continue;
         }
@@ -156,6 +152,9 @@ Sails::WURCS::calculate_residue_order(Sails::Glycan *glycan, Sails::ResidueDatab
     }
     return order;
 }
+
+// WURCS PARSING
+
 
 std::vector<std::string> Sails::WURCS::extract_wurcs_unique_residues(const std::string &wurcs) {
     std::regex regex(R"(\[\S*\])");
@@ -167,10 +166,10 @@ std::vector<std::string> Sails::WURCS::extract_wurcs_unique_residues(const std::
         results.push_back(it->str());
     }
 
-    if (results.empty() || results.size() > 1) {throw std::runtime_error("Error in WURCS Unique Residue List");}
+    if (results.empty() || results.size() > 1) { throw std::runtime_error("Error in WURCS Unique Residue List"); }
 
     std::vector<std::string> order = Utils::split(results[0], ']');
-    for (auto & i : order) {
+    for (auto &i: order) {
         i.erase(0, 1);
     }
 
@@ -187,14 +186,14 @@ std::vector<int> Sails::WURCS::extract_wurcs_residue_order(const std::string &wu
         results.push_back(it->str());
     }
 
-    if (results.empty() || results.size() > 1) {throw std::runtime_error("Error in WURCS Residue Order");}
+    if (results.empty() || results.size() > 1) { throw std::runtime_error("Error in WURCS Residue Order"); }
 
     std::string order_string = results[0];
     order_string = order_string.substr(1, order_string.size() - 2);
 
     std::vector<std::string> order = Utils::split(order_string, '-');
     std::vector<int> residue_order;
-    for (auto & it : order) {
+    for (auto &it: order) {
         residue_order.emplace_back(atoi(it.c_str()));
     }
     return residue_order;
@@ -214,73 +213,106 @@ std::vector<std::string> Sails::WURCS::extract_wurcs_linkage_order(const std::st
 }
 
 
-// WURCS PARSING
-//WURCS=2.0/3,7,6/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]/1-1-2-3-3-3-3/a4-b1_b4-c1_c3-d1_c6-e1_e3-f1_f2-g1
-Sails::Glycan Sails::WURCS::generate_pseudo_glycan(const std::string &wurcs, gemmi::Structure *structure, Sails::LinkageDatabase &linkage_database, Sails::ResidueDatabase &residue_database) {
-
-
-    std::vector<std::string> unique_residues = extract_wurcs_unique_residues(wurcs);
-    std::vector<int> residue_order = extract_wurcs_residue_order(wurcs);
-    std::vector<std::string> linkage_order = extract_wurcs_linkage_order(wurcs);
-
+std::vector<std::string> Sails::WURCS::form_residue_name_order(ResidueDatabase &residue_database,
+                                                               std::vector<std::string> unique_residues,
+                                                               std::vector<int> residue_order) {
     std::vector<std::string> unique_residue_names;
-    for (auto& wurcs_residue_id: unique_residues) {
-        std::optional<std::string> key = get_key(residue_database, [&](const ResidueData& data){return data.wurcs_code == wurcs_residue_id;});
-        if (!key.has_value()) { throw std::runtime_error("Cannot create psuedo-glycan, an unknown residue was found."); }
+    for (auto &wurcs_residue_id: unique_residues) {
+        std::optional<std::string> key = get_key(residue_database, [&](const ResidueData &data) {
+            return data.wurcs_code == wurcs_residue_id;
+        });
+        if (!key.has_value()) {
+            throw std::runtime_error("Cannot create psuedo-glycan, an unknown residue was found.");
+        }
         unique_residue_names.emplace_back(key.value());
     }
 
     std::vector<std::string> residue_name_order;
     residue_name_order.reserve(residue_order.size());
-    for (auto& order: residue_order) {
-        residue_name_order.emplace_back(unique_residue_names[order-1]);
+    for (auto &order: residue_order) {
+        residue_name_order.emplace_back(unique_residue_names[order - 1]);
     }
 
+    return residue_name_order;
+}
+
+gemmi::Structure Sails::WURCS::generate_pseudo_structure() {
     gemmi::Structure pseudo_structure;
     gemmi::Model pseudo_model;
     gemmi::Chain chain = gemmi::Chain("A");
-    std::vector<Glycosite> glycosites;
 
+    pseudo_model.chains.emplace_back(chain);
+    pseudo_structure.models.emplace_back(pseudo_model);
+    return pseudo_structure;
+}
+
+void Sails::WURCS::add_linkage_to_pseudo_glycan(std::vector<Glycosite> &glycosites, PseudoGlycan &pseudo_glycan,
+                                                const std::string &linkage_string) {
+    std::vector<std::string> split_linkage = Utils::split(linkage_string, '-');
+    const std::string &donor_linkage = split_linkage[0];
+    const std::string &acceptor_linkage = split_linkage[1];
+
+    int donor_sugar = donor_linkage[0] - 'a';
+    std::string donor_atom = "C";
+    donor_atom += donor_linkage[1];
+    int acceptor_sugar = acceptor_linkage[0] - 'a';
+    std::string acceptor_atom = "C";
+    acceptor_atom += acceptor_linkage[1];
+
+    pseudo_glycan.add_linkage(glycosites[donor_sugar], glycosites[acceptor_sugar], donor_atom, acceptor_atom);
+}
+
+//WURCS=2.0/3,7,6/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]/1-1-2-3-3-3-3/a4-b1_b4-c1_c3-d1_c6-e1_e3-f1_f2-g1
+Sails::Glycan Sails::WURCS::generate_pseudo_glycan(const std::string &wurcs,
+                                                   gemmi::Structure *structure,
+                                                   Glycosite &glycosite,
+                                                   LinkageDatabase &linkage_database, ResidueDatabase &residue_database) {
+    std::vector<std::string> unique_residues = extract_wurcs_unique_residues(wurcs);
+    std::vector<int> residue_order = extract_wurcs_residue_order(wurcs);
+    std::vector<std::string> linkage_order = extract_wurcs_linkage_order(wurcs);
+
+    std::vector<std::string> residue_name_order = form_residue_name_order(
+        residue_database, unique_residues, residue_order);
+
+    if (structure != nullptr) {
+        structure->models[0].chains.emplace_back("X");
+    }
+        // gemmi::Structure pseudo_structure = generate_pseudo_structure();
+        // structure = &pseudo_structure;
+
+    std::vector<Glycosite> glycosites;
     for (int i = 0; i < residue_name_order.size(); i++) {
         gemmi::Residue residue;
         residue.seqid = gemmi::SeqId(std::to_string(i));
         residue.name = residue_name_order[i];
-        chain.residues.emplace_back(residue);
-        glycosites.emplace_back(0, 0, i);
+        auto last_chain = Utils::get_last_chain(structure);
+        if (!last_chain.has_value()) {throw std::runtime_error("The structure must contain at least one chain.");}
+        last_chain.value()->residues.emplace_back(residue);
+        int last_chain_index = Utils::get_last_chain_index(structure);
+        glycosites.emplace_back(0, last_chain_index, i);
     }
-    pseudo_model.chains.emplace_back(chain);
-    pseudo_structure.models.emplace_back(pseudo_model);
 
-    PseudoGlycan pseudo_glycan = {&pseudo_structure, residue_database, glycosites[0]};
+    PseudoGlycan pseudo_glycan = {structure, residue_database, glycosite};
+    pseudo_glycan.add_sugar("", 0, glycosite);
 
     for (int i = 0; i < residue_name_order.size(); i++) {
-        pseudo_glycan.add_sugar("", i, glycosites[i]);
+        pseudo_glycan.add_sugar("", i+1, glycosites[i]);
     }
 
-    for (const auto & i : linkage_order) {
-        std::vector<std::string> split_linkage = Utils::split(i, '-');
-        const std::string& donor_linkage = split_linkage[0];
-        const std::string& acceptor_linkage = split_linkage[1];
-
-        int donor_sugar = donor_linkage[0] - 'a';
-        std::string donor_atom = "C";
-        donor_atom += donor_linkage[1];
-        int acceptor_sugar = acceptor_linkage[0] - 'a';
-        std::string acceptor_atom  = "C";
-        acceptor_atom += acceptor_linkage[1];
-
-        pseudo_glycan.add_linkage(glycosites[donor_sugar], glycosites[acceptor_sugar], donor_atom, acceptor_atom);
+    pseudo_glycan.add_linkage(glycosite, glycosites[0], "ND2","C1");
+    for (const auto &linkage: linkage_order) {
+        add_linkage_to_pseudo_glycan(glycosites, pseudo_glycan, linkage);
     }
 
-    Sails::Model model = {&pseudo_structure, linkage_database, residue_database};
+    Model model = {structure, linkage_database, residue_database};
     model.create_pseudo_glycan(pseudo_glycan);
 
-    return Sails::Glycan();
+    return pseudo_glycan;
 }
 
 template<typename key, typename value, typename Predicate>
 std::optional<key> Sails::WURCS::get_key(const std::map<key, value> &map, Predicate predicate) {
-    for (const auto& [k, v] : map) {
+    for (const auto &[k, v]: map) {
         if (predicate(v)) {
             return k;
         }

--- a/package/src/cpp/sails-wurcs.cpp
+++ b/package/src/cpp/sails-wurcs.cpp
@@ -1,0 +1,48 @@
+//
+// Created by jordan on 05/11/24.
+//
+
+#include "../include/sails-wurcs.h"
+
+std::string Sails::WURCS::generate_wurcs(Sails::Glycan *glycan, Sails::ResidueDatabase& residue_database) {
+
+    std::stringstream wurcs;
+
+    wurcs << get_wurcs_header() << get_section_delimiter();
+    wurcs << get_unit_count(glycan) << get_section_delimiter();
+    wurcs << get_unique_residue_list(glycan, residue_database) << get_section_delimiter();
+
+    return wurcs.str();
+}
+
+Sails::Glycan Sails::WURCS::generate_psuedo_glycan(const std::string &wurcs, gemmi::Structure *structure) {
+    return Sails::Glycan();
+}
+
+std::string Sails::WURCS::get_unit_count(Sails::Glycan *glycan) {
+    std::stringstream unit_count;
+
+    unit_count << glycan->unique_sugar_count() << ",";
+    unit_count << glycan->sugar_count() << ",";
+    unit_count << glycan->linkage_count();
+    return unit_count.str();
+}
+
+std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
+
+    std::vector<std::string> unique_sugars = glycan->get_unique_sugar_names();
+
+    std::stringstream unique_residues;
+    for (auto& sugar: unique_sugars) {
+        if (residue_database.find(sugar) == residue_database.end()) {
+            unique_residues << "[" << sugar << "]";
+            continue;
+        }
+        std::optional<std::string> wurcs = residue_database[sugar].wurcs_code;
+        if (!wurcs.has_value()) {continue;} // an ASN, TRP, etc. would not have a WURCS code
+
+        unique_residues << "[" << wurcs.value() << "]";
+    }
+
+    return unique_residues.str();
+}

--- a/package/src/cpp/sails-wurcs.cpp
+++ b/package/src/cpp/sails-wurcs.cpp
@@ -12,6 +12,7 @@ std::string Sails::WURCS::generate_wurcs(Sails::Glycan *glycan, Sails::ResidueDa
     wurcs << get_unit_count(glycan) << get_section_delimiter();
     wurcs << get_unique_residue_list(glycan, residue_database) << get_section_delimiter();
     wurcs << get_residue_order(glycan, residue_database) << get_section_delimiter();
+    wurcs << get_link_list(glycan, residue_database) << get_section_delimiter();
     return wurcs.str();
 }
 
@@ -34,7 +35,6 @@ std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::
 
     std::stringstream unique_residues;
     for (auto& sugar: unique_sugars) {
-        std::cout << sugar << std::endl;
         if (residue_database.find(sugar) == residue_database.end()) {
             unique_residues << "[" << sugar << "]";
             continue;
@@ -50,12 +50,92 @@ std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::
 
 std::string Sails::WURCS::get_residue_order(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
 
+    std::vector<int> order = calculate_residue_order(glycan, residue_database);
+
+    std::stringstream residue_order;
+    for (int i = 0; i < order.size(); i++) {
+        residue_order << order[i];
+
+        if (i != order.size() - 1) {
+            residue_order << "-";
+        }
+    }
+
+    return residue_order.str();
+}
+
+std::string Sails::WURCS::get_link_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
+
+    std::vector<int> order = calculate_residue_order(glycan, residue_database);
+    auto sugar_sites = glycan->get_sugar_site_order();
+    auto sugar_names = glycan->get_sugar_name_order();
+
+    auto sugars = glycan->get_sugars();
+    auto adjacency_list = glycan->get_adjacency_list();
+
+    char alphabet[] = "abcdefghijklmnopqrstuvxyz";
+    std::map<Glycosite, char> site_map;
+    int alphabet_count = 0;
+    for (int i = 0; i < sugar_sites.size(); i++) {
+        if (residue_database.find(sugar_names[i]) == residue_database.end()) {
+            continue;
+        }
+        std::optional<std::string> wurcs = residue_database[sugar_names[i]].wurcs_code;
+        if (!wurcs.has_value()) {continue;}
+
+        site_map[sugar_sites[i]] = alphabet[alphabet_count];
+        alphabet_count++;
+    }
+
+    std::vector<std::string> linkage_order;
+
+    for (auto& site: sugar_sites) {
+        Sugar* sugar_ptr = sugars->at(site).get();
+        if (adjacency_list->find(sugar_ptr) == adjacency_list->end()) {
+            continue;
+        }
+
+        std::set<Sugar*> linked_sugars = adjacency_list->at(sugar_ptr);
+
+        for (auto& linked_sugar: linked_sugars) {
+            Linkage* linkage = sugar_ptr->find_linkage(sugar_ptr, linked_sugar);
+
+            if (site_map.find(linkage->donor_sugar->site) == site_map.end()) {
+                continue;
+            }
+
+            if (site_map.find(linkage->acceptor_sugar->site) == site_map.end()) {
+                continue;
+            }
+
+            std::stringstream linkage_string;
+            linkage_string << site_map.at(linkage->donor_sugar->site) << linkage->donor_atom.back();
+            linkage_string << "-";
+            linkage_string << site_map.at(linkage->acceptor_sugar->site) << linkage->acceptor_atom.back();
+            linkage_order.emplace_back(linkage_string.str());
+        }
+    }
+
+    std::stringstream linkage_stream;
+    for (int i = 0; i < linkage_order.size(); i++) {
+        linkage_stream << linkage_order[i];
+        if (i < linkage_order.size()-1) {
+            linkage_stream << "_";
+        }
+    }
+
+    return linkage_stream.str();
+}
+
+std::vector<int>
+Sails::WURCS::calculate_residue_order(const Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
     std::vector<std::string> sugar_order = glycan->get_sugar_name_order();
     std::vector<std::string> unique_sugars = glycan->get_unique_sugar_names();
     std::map<std::string, int> sugar_indices;
 
     for (int i = 0; i < unique_sugars.size(); i++) {
-        std::optional<std::string> wurcs = residue_database[unique_sugars[i]].wurcs_code;
+        std::string unique_sugar = unique_sugars[i];
+        std::optional<std::string> wurcs = residue_database[unique_sugar].wurcs_code;
         if (!wurcs.has_value()) {continue;}
         sugar_indices[unique_sugars[i]] = i;
     }
@@ -68,15 +148,5 @@ std::string Sails::WURCS::get_residue_order(Sails::Glycan *glycan, Sails::Residu
         int index = sugar_indices[name];
         order.emplace_back(index);
     }
-
-    std::stringstream residue_order;
-    for (int i = 0; i < order.size(); i++) {
-        residue_order << order[i];
-
-        if (i != order.size() - 1) {
-            residue_order << "-";
-        }
-    }
-
-    return residue_order.str();
+    return order;
 }

--- a/package/src/cpp/sails-wurcs.cpp
+++ b/package/src/cpp/sails-wurcs.cpp
@@ -34,6 +34,7 @@ std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::
 
     std::stringstream unique_residues;
     for (auto& sugar: unique_sugars) {
+        std::cout << sugar << std::endl;
         if (residue_database.find(sugar) == residue_database.end()) {
             unique_residues << "[" << sugar << "]";
             continue;

--- a/package/src/cpp/sails-wurcs.cpp
+++ b/package/src/cpp/sails-wurcs.cpp
@@ -11,7 +11,7 @@ std::string Sails::WURCS::generate_wurcs(Sails::Glycan *glycan, Sails::ResidueDa
     wurcs << get_wurcs_header() << get_section_delimiter();
     wurcs << get_unit_count(glycan) << get_section_delimiter();
     wurcs << get_unique_residue_list(glycan, residue_database) << get_section_delimiter();
-
+    wurcs << get_residue_order(glycan, residue_database) << get_section_delimiter();
     return wurcs.str();
 }
 
@@ -46,4 +46,37 @@ std::string Sails::WURCS::get_unique_residue_list(Sails::Glycan *glycan, Sails::
     }
 
     return unique_residues.str();
+}
+
+std::string Sails::WURCS::get_residue_order(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database) {
+
+    std::vector<std::string> sugar_order = glycan->get_sugar_name_order();
+    std::vector<std::string> unique_sugars = glycan->get_unique_sugar_names();
+    std::map<std::string, int> sugar_indices;
+
+    for (int i = 0; i < unique_sugars.size(); i++) {
+        std::optional<std::string> wurcs = residue_database[unique_sugars[i]].wurcs_code;
+        if (!wurcs.has_value()) {continue;}
+        sugar_indices[unique_sugars[i]] = i;
+    }
+
+    std::vector<int> order ;
+    for (const auto& name: sugar_order) {
+        if (sugar_indices.find(name) == sugar_indices.end()) {
+            continue;
+        }
+        int index = sugar_indices[name];
+        order.emplace_back(index);
+    }
+
+    std::stringstream residue_order;
+    for (int i = 0; i < order.size(); i++) {
+        residue_order << order[i];
+
+        if (i != order.size() - 1) {
+            residue_order << "-";
+        }
+    }
+
+    return residue_order.str();
 }

--- a/package/src/cpp/sails.cpp
+++ b/package/src/cpp/sails.cpp
@@ -12,6 +12,7 @@
 #include "../include/sails-linkage.h"
 #include "../include/sails-cif.h"
 #include "../include/sails-telemetry.h"
+#include "../include/sails-wurcs.h"
 #include "../include/snfg/sails-snfg.h"
 #include <src/include/sails-gemmi-bindings.h>
 #include <src/include/sails-solvent.h>
@@ -361,6 +362,28 @@ std::map<std::string, std::string> get_all_snfgs(gemmi::Structure& structure, st
     }
 
     return snfg_map;
+}
+
+//sails-wurcs -modelin ../testing/test_data/5fji/5FJI.cif -chain A -res 61
+//
+//DESIRED:
+//WURCS=2.0/3,7,6/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]/1-1-2-3-3-3-3/a4-b1_b4-c1_c3-d1_c6-e1_e3-f1_f2-g1
+gemmi::Structure wurcs(gemmi::Structure& structure, std::string chain, int seqid, std::string& resource_dir) {
+    std::string data_file = resource_dir + "/data.json";
+    Sails::JSONLoader loader = {data_file};
+    Sails::ResidueDatabase residue_database = loader.load_residue_database();
+
+    Sails::Topology topology = {&structure, residue_database};
+
+    std::optional<Sails::Glycosite> potential_glycosite = Sails::find_site(structure, chain, seqid);
+    if (!potential_glycosite.has_value()) throw std::runtime_error("Could not find specified site");
+    Sails::Glycosite glycosite = potential_glycosite.value();
+
+    Sails::Glycan glycan = topology.find_glycan_topology(glycosite);
+
+    std::cout << Sails::WURCS::generate_wurcs(&glycan, residue_database) << std::endl;
+
+    return structure;
 }
 
 void test() {

--- a/package/src/include/sails-glycan.h
+++ b/package/src/include/sails-glycan.h
@@ -647,8 +647,14 @@ namespace Sails {
         */
         std::vector<Glycosite> sugar_order;
 
-
     };
+
+    struct PseudoGlycan: Glycan {
+        PseudoGlycan(gemmi::Structure *structure, ResidueDatabase &database, Glycosite &glycosite)
+            : Glycan(structure, database, glycosite) {
+        }
+    };
+
 }
 
 #endif //SAILS_SAILS_GLYCAN_H

--- a/package/src/include/sails-glycan.h
+++ b/package/src/include/sails-glycan.h
@@ -225,6 +225,29 @@ namespace Sails {
         }
 
         /**
+         * @brief Returns the order of the sugars sites.
+         *
+         * @return A vector of Glycosites in order
+         */
+        [[nodiscard]] std::vector<Sails::Glycosite> get_sugar_site_order() const {
+            return sugar_order;
+        }
+
+        /**
+         * @brief Returns the order of the sugars.
+         *
+         * @return A vector of names of sugars in order e.g. NAG,NAG,BMA,MAN
+         */
+        [[nodiscard]] std::vector<std::string> get_sugar_name_order() const {
+            std::vector<std::string> names;
+            names.reserve(sugar_order.size());
+            for (const auto &sugar: sugar_order) {
+                names.emplace_back(Utils::get_residue_ptr_from_glycosite(sugar, m_structure)->name);
+            }
+            return names;
+        }
+
+        /**
          * @brief Returns the number of unique sugars.
          *
          * @return The number of unique sugars

--- a/package/src/include/sails-glycan.h
+++ b/package/src/include/sails-glycan.h
@@ -375,19 +375,19 @@ namespace Sails {
          *
          * @param atom The type of atom in the sugar molecule.
          * @param seqId The sequence ID of the sugar molecule.
-         * @param residue The glycosite of the sugar molecule.
+         * @param site The glycosite of the sugar molecule.
          */
-        void add_sugar(const std::string &atom, int seqId, Glycosite &residue) {
-            if (sugars.find(residue) != sugars.end()) {
+        void add_sugar(const std::string &atom, int seqId, Glycosite &site) {
+            if (sugars.find(site) != sugars.end()) {
                 // this sugar was already added, don't overwrite
                 return;
             }
-            sugars[residue] = std::make_unique<Sugar>(atom, seqId, residue);
-            gemmi::Residue* residue_ptr = Utils::get_residue_ptr_from_glycosite(residue, m_structure);
+            sugars[site] = std::make_unique<Sugar>(atom, seqId, site);
+            gemmi::Residue* residue_ptr = Utils::get_residue_ptr_from_glycosite(site, m_structure);
 
             if (sugar_order.empty()) {
-                root_glycosite = residue;
-                root_sugar = sugars[residue].get();
+                root_glycosite = site;
+                root_sugar = sugars[site].get();
             }
 
             if (sugar_counts.find(residue_ptr->name) == sugar_counts.end()) {
@@ -395,7 +395,7 @@ namespace Sails {
             } else {
                 sugar_counts[residue_ptr->name] = sugar_counts[residue_ptr->name] + 1;
             }
-            sugar_order.emplace_back(residue);
+            sugar_order.emplace_back(site);
         }
 
         /**

--- a/package/src/include/sails-glycan.h
+++ b/package/src/include/sails-glycan.h
@@ -269,6 +269,33 @@ namespace Sails {
         }
 
         /**
+         * @brief Returns internal adjacency list.
+         *
+         * @return A map of sugar ptrs to a set of linked sugar ptrs.
+         */
+        [[nodiscard]] const std::map<Sugar*, std::set<Sugar*>>* get_adjacency_list() const {
+            return &adjacency_list;
+        }
+
+        /**
+         * @brief Returns the linkages in this glycan.
+         *
+         * @return A ptr to a vector of of linkages.
+         */
+        [[nodiscard]] const std::vector<Linkage>* get_linkage_list() const {
+            return &linkage_list;
+        }
+
+        /**
+         * @brief Returns the sugars in this glycan.
+         *
+         * @return A ptr to a all sugars in this glycan.
+         */
+        [[nodiscard]] const std::map<Glycosite, std::unique_ptr<Sugar>>* get_sugars() const {
+            return &sugars;
+        }
+
+        /**
          * @brief Adds linkage between two sugars.
          *
          * This function creates a linkage between two sugars by the seqId. Sugars must have been added with add_sugar

--- a/package/src/include/sails-model.h
+++ b/package/src/include/sails-model.h
@@ -58,27 +58,18 @@ namespace Sails {
     struct ResidueData {
         ResidueData() = default;
 
-        ResidueData(const std::vector<AtomSet> &acceptors, const std::vector<AtomSet> &donors, std::string& snfg_shape,
-                    std::string& snfg_colour, std::vector<int> &preferred_depths, std::string& anomer,
-                    std::string& wurcs
-                    ) : acceptors(acceptors), donors(donors),
+        ResidueData(const std::vector<AtomSet> &acceptors, const std::vector<AtomSet> &donors, std::string &snfg_shape,
+                    std::string &snfg_colour, std::vector<int> &preferred_depths, std::string &anomer,
+                    std::string &wurcs, bool special
+        ) : acceptors(acceptors), donors(donors),
             snfg_shape(std::move(snfg_shape)),
             snfg_colour(std::move(snfg_colour)),
             preferred_depths(preferred_depths),
-            anomer(anomer) {
+            anomer(anomer), special(special) {
             if (!wurcs.empty()) {
                 wurcs_code = wurcs;
             }
-        }
 
-        ResidueData(const std::vector<AtomSet> &acceptors, const std::vector<AtomSet> &donors, std::string &snfg_shape,
-                    std::string &snfg_colour, const std::vector<int> &preferred_depths, const std::string &anomer,
-                    const bool special) : acceptors(acceptors), donors(donors),
-                                          snfg_shape(std::move(snfg_shape)),
-                                          snfg_colour(std::move(snfg_colour)),
-                                          preferred_depths(preferred_depths),
-                                          anomer(anomer),
-                                          special(special) {
             for (const auto &acceptor: acceptors) {
                 acceptor_map[acceptor.identifier] = acceptor.get_atom_list();
             }
@@ -87,6 +78,7 @@ namespace Sails {
                 donor_map[donor.identifier] = donor.get_atom_list();
             }
         }
+
 
         std::map<int, std::vector<std::string> > acceptor_map;
         std::map<int, std::vector<std::string> > donor_map;

--- a/package/src/include/sails-model.h
+++ b/package/src/include/sails-model.h
@@ -56,11 +56,16 @@ namespace Sails {
         ResidueData() = default;
 
         ResidueData(const std::vector<AtomSet> &acceptors, const std::vector<AtomSet> &donors, std::string& snfg_shape,
-                    std::string& snfg_colour, std::vector<int> &preferred_depths, std::string& anomer) : acceptors(acceptors), donors(donors),
+                    std::string& snfg_colour, std::vector<int> &preferred_depths, std::string& anomer,
+                    std::string& wurcs
+                    ) : acceptors(acceptors), donors(donors),
             snfg_shape(std::move(snfg_shape)),
             snfg_colour(std::move(snfg_colour)),
             preferred_depths(preferred_depths),
             anomer(anomer) {
+
+            if (!wurcs.empty()) {wurcs_code = wurcs;}
+
             for (const auto &acceptor: acceptors) {
                 acceptor_map[acceptor.identifier] = acceptor.get_atom_list();
             }
@@ -78,6 +83,7 @@ namespace Sails {
         std::string snfg_colour;
         std::vector<int> preferred_depths;
         std::string anomer;
+        std::optional<std::string> wurcs_code = std::nullopt;
     };
 
     typedef std::map<std::string, ResidueData> ResidueDatabase;

--- a/package/src/include/sails-utils.h
+++ b/package/src/include/sails-utils.h
@@ -80,7 +80,7 @@ namespace Sails::Utils {
   *
   * @return The formatted key for the site.
   */
- std::string format_site_key(const Glycosite& glycosite);
+ std::string format_site_key(const Glycosite &glycosite);
 
  /**
    * @brief Formats the key of the residue for a given glycosite.
@@ -92,7 +92,7 @@ namespace Sails::Utils {
    *
    * @return The formatted key for the site.
    */
- std::string format_residue_from_site(const Glycosite& glycosite, gemmi::Structure *structure);
+ std::string format_residue_from_site(const Glycosite &glycosite, gemmi::Structure *structure);
 
 
  /**
@@ -106,7 +106,7 @@ namespace Sails::Utils {
   *
   * @return The gemmi::Chain object from the specified glycosute.
   */
- gemmi::Chain get_chain_from_glycosite(const Glycosite &site, const gemmi::Structure* structure);
+ gemmi::Chain get_chain_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
 
  /**
   * @brief Retrieves the gemmi::Residue corresponding to a given Glycosite.
@@ -119,7 +119,7 @@ namespace Sails::Utils {
   *
   * @return The gemmi::Residue from the specified glycosite.
   */
- gemmi::Residue get_residue_from_glycosite(const Glycosite &site, const gemmi::Structure* structure);
+ gemmi::Residue get_residue_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
 
  /**
  * @brief Retrieves the gemmi::Residue pointer corresponding to a given Glycosite.
@@ -132,7 +132,7 @@ namespace Sails::Utils {
  *
  * @return The gemmi::Residue pointer from the specified glycosite.
  */
- gemmi::Residue* get_residue_ptr_from_glycosite(const Glycosite &site, gemmi::Structure* structure);
+ gemmi::Residue *get_residue_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
 
  /**
  * @brief Retrieves the gemmi::Chain pointer corresponding to a given Glycosite.
@@ -145,7 +145,7 @@ namespace Sails::Utils {
  *
  * @return The gemmi::Chain pointer from the specified glycosite.
  */
- gemmi::Chain* get_chain_ptr_from_glycosite(const Glycosite &site, gemmi::Structure* structure);
+ gemmi::Chain *get_chain_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
 
  /**
   * @brief Retrieves the gemmi::Atom from the specified glycosite.
@@ -159,7 +159,7 @@ namespace Sails::Utils {
   * @return The gemmi::Atom from the specified glycosite.
   * @throws std::runtime_error if the site has not been initialised from a Mark.
   */
- gemmi::Atom get_atom_from_glycosite(const Glycosite &site, const gemmi::Structure* structure);
+ gemmi::Atom get_atom_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
 
  /**
   * @brief Converts the given LinkageData object into an ID string.
@@ -209,7 +209,7 @@ namespace Sails::Utils {
   * @param structure The gemmi::Structure object to be saved.
   * @param path The path of the file where the structure should be saved.
   */
- void save_structure_to_file(const gemmi::Structure& structure, const std::string& path);
+ void save_structure_to_file(const gemmi::Structure &structure, const std::string &path);
 
 
  /**
@@ -221,7 +221,7 @@ namespace Sails::Utils {
   * @param input The string to increment.
   * @return The incremented string.
   */
- std::string get_next_string(const std::string& input);
+ std::string get_next_string(const std::string &input);
 
  /**
   * @brief Checks if a file exists at the specified path.
@@ -232,7 +232,17 @@ namespace Sails::Utils {
   *
   * @return true if the file exists, false otherwise.
   */
- bool file_exists(const std::string& path);
+ bool file_exists(const std::string &path);
+
+ /**
+  * @brief Splits a string by delimiter
+  *
+  * @param string The string to split
+  * @param delimiter The delimiter to split at
+  *
+  * @return a vector of strings split by the delimiter
+  */
+ std::vector<std::string> split(const std::string &string, char delimiter);
 
 } // namespace Sails::Utils
 

--- a/package/src/include/sails-utils.h
+++ b/package/src/include/sails-utils.h
@@ -17,233 +17,246 @@
 #include "sails-model.h"
 
 namespace Sails::Utils {
- /**
-  * @brief Retrieves the value of the specified environment variable.
-  *
-  * This function retrieves the value of the specified environment variable identified by the provided key.
-  *
-  * @param key The name of the environment variable to retrieve.
-  *
-  * @return The value of the specified environment variable. If the environment variable is not found,
-  *         an empty string is returned.
-  */
- std::string get_environment_variable(std::string const &key);
+    /**
+     * @brief Retrieves the value of the specified environment variable.
+     *
+     * This function retrieves the value of the specified environment variable identified by the provided key.
+     *
+     * @param key The name of the environment variable to retrieve.
+     *
+     * @return The value of the specified environment variable. If the environment variable is not found,
+     *         an empty string is returned.
+     */
+    std::string get_environment_variable(std::string const &key);
 
- /**
-  * @brief Prints the components of the given vector.
-  *
-  * This method prints the x, y, and z components of the provided vector using the format "(x, y, z)" using the
-  * std::cout stream
-  *
-  * @param vec The gemmi::Vec3 object whose coordinates will be printed.
-  */
- void print_vector(const gemmi::Vec3 &vec);
+    /**
+     * @brief Prints the components of the given vector.
+     *
+     * This method prints the x, y, and z components of the provided vector using the format "(x, y, z)" using the
+     * std::cout stream
+     *
+     * @param vec The gemmi::Vec3 object whose coordinates will be printed.
+     */
+    void print_vector(const gemmi::Vec3 &vec);
 
- /**
-    * @brief Prints the components of the given vector with given label prefix.
+    /**
+       * @brief Prints the components of the given vector with given label prefix.
+       *
+       * This method prints the x, y, and z components of the provided vector using the format "(x, y, z)" using the
+       * std::cout stream
+       *
+       * @param vec The gemmi::Vec3 object whose coordinates will be printed.
+       */
+    void print_vector(const gemmi::Vec3 &vec, const std::string &name);
+
+    /**
+     * @brief Prints the coordinates of a given gemmi::Position object.
+     *
+     * This method prints the x, y, and z components of the provided position using the format "(x, y, z)" using the
+     * std::cout stream
+     *
+     * @param position The gemmi::Position object whose coordinates will be printed.
+     */
+    void print_position(const gemmi::Position &position);
+
+    /**
+     * @brief Formats the key for a given residue.
+     *
+     * This function formats the key for the provided residue by concatenating its name and sequence identifier.
+     *
+     * @param residue A pointer to the gemmi::Residue object representing the residue.
+     *
+     * @return The formatted key for the residue.
+     */
+    std::string format_residue_key(const gemmi::Residue *residue);
+
+
+    /**
+     * @brief Formats the key for a given glycosite.
+     *
+     * This function formats the key for the provided residue by concatenating its the model, chain, residue and atom ids.
+     *
+     * @param glycosite A glycosite
+     *
+     * @return The formatted key for the site.
+     */
+    std::string format_site_key(const Glycosite &glycosite);
+
+    /**
+      * @brief Formats the key of the residue for a given glycosite.
+      *
+      * This function formats the key for the provided glycosite by getting chain ID, residue name and residue SeqId.
+      *
+      * @param glycosite A glycosite
+      * @param structure
+      *
+      * @return The formatted key for the site.
+      */
+    std::string format_residue_from_site(const Glycosite &glycosite, gemmi::Structure *structure);
+
+
+    /**
+     * @brief Retrieves the gemmi::Chain object corresponding to a given Glycosite.
+     *
+     * This function retrieves the gemmi::Chain object that represents the chain of the
+     * provided Glycosite within the specified gemmi::Structure.
+     *
+     * @param site The glycosite object containing the model, chain, and residue indices.
+     * @param structure A ptr to a gemmi::Structure object from which the chain is to be retrieved.
+     *
+     * @return The gemmi::Chain object from the specified glycosute.
+     */
+    gemmi::Chain get_chain_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
+
+    /**
+     * @brief Retrieves the gemmi::Residue corresponding to a given Glycosite.
+     *
+     * This function retrieves the gemmi::Residue object that represents the residue of the
+     * provided Glycosite within the specified gemmi::Structure.
+     *
+     * @param site The glycosite object containing the model, chain, and residue indices.
+     * @param structure A ptr to a structure object from which to retrieve the residue.
+     *
+     * @return The gemmi::Residue from the specified glycosite.
+     */
+    gemmi::Residue get_residue_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
+
+    /**
+    * @brief Retrieves the gemmi::Residue pointer corresponding to a given Glycosite.
     *
-    * This method prints the x, y, and z components of the provided vector using the format "(x, y, z)" using the
-    * std::cout stream
+    * This function retrieves the gemmi::Residue pointer that represents the residue of the
+    * provided Glycosite within the specified gemmi::Structure.
     *
-    * @param vec The gemmi::Vec3 object whose coordinates will be printed.
+    * @param site The glycosite object containing the model, chain, and residue indices.
+    * @param structure A ptr to a structure object from which to retrieve the residue.
+    *
+    * @return The gemmi::Residue pointer from the specified glycosite.
     */
- void print_vector(const gemmi::Vec3 &vec, const std::string &name);
+    gemmi::Residue *get_residue_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
 
- /**
-  * @brief Prints the coordinates of a given gemmi::Position object.
-  *
-  * This method prints the x, y, and z components of the provided position using the format "(x, y, z)" using the
-  * std::cout stream
-  *
-  * @param position The gemmi::Position object whose coordinates will be printed.
-  */
- void print_position(const gemmi::Position &position);
+    /**
+    * @brief Retrieves the gemmi::Chain pointer corresponding to a given Glycosite.
+    *
+    * This function retrieves the gemmi::Chain pointer that represents the chain of the
+    * provided Glycosite within the specified gemmi::Structure.
+    *
+    * @param site The glycosite object containing the model, chain, and residue indices.
+    * @param structure A ptr to a structure object from which to retrieve the chain.
+    *
+    * @return The gemmi::Chain pointer from the specified glycosite.
+    */
+    gemmi::Chain *get_chain_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
 
- /**
-  * @brief Formats the key for a given residue.
-  *
-  * This function formats the key for the provided residue by concatenating its name and sequence identifier.
-  *
-  * @param residue A pointer to the gemmi::Residue object representing the residue.
-  *
-  * @return The formatted key for the residue.
-  */
- std::string format_residue_key(const gemmi::Residue *residue);
+    /**
+     * @brief Retrieves the gemmi::Atom from the specified glycosite.
+     *
+     * This function retrieves the gemmi::Atom object that represents the atom of the
+     * provided Glycosite within the specified gemmi::Structure.
+     *
+     * @param site The glycosite object containing the model, chain, and residue indices.
+     * @param structure The structure from which to retrieve the atom.
+     *
+     * @return The gemmi::Atom from the specified glycosite.
+     * @throws std::runtime_error if the site has not been initialised from a Mark.
+     */
+    gemmi::Atom get_atom_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
 
+    /**
+    * @brief Retrieve a ptr to the last chain in a gemmi Structure
+    *
+    * @return an optional gemmi::Chain* if there is at least 1 chain in a ptr, or a nulloption if there are no chains
+    */
+    std::optional<gemmi::Chain*> get_last_chain(gemmi::Structure *structure);
 
- /**
-  * @brief Formats the key for a given glycosite.
-  *
-  * This function formats the key for the provided residue by concatenating its the model, chain, residue and atom ids.
-  *
-  * @param glycosite A glycosite
-  *
-  * @return The formatted key for the site.
-  */
- std::string format_site_key(const Glycosite &glycosite);
+    /**
+    * @brief Retrieve the index of the last chain in the gemmi Structure
+    *
+    * @return the index of the last chain in the gemmi Structure
+    */
+    int get_last_chain_index(gemmi::Structure *structure);
 
- /**
-   * @brief Formats the key of the residue for a given glycosite.
-   *
-   * This function formats the key for the provided glycosite by getting chain ID, residue name and residue SeqId.
-   *
-   * @param glycosite A glycosite
-   * @param structure
-   *
-   * @return The formatted key for the site.
-   */
- std::string format_residue_from_site(const Glycosite &glycosite, gemmi::Structure *structure);
+    /**
+     * @brief Converts the given LinkageData object into an ID string.
+     *
+     * This function takes a reference to a LinkageData object and converts it into an ID string. The ID string is constructed
+     * by concatenating the donor, donor_number, acceptor_number, and acceptor fields of the LinkageData object.
+     *
+     * @param data The LinkageData object to convert to an ID string.
+     *
+     * @return The ID string representation of the LinkageData object.
+     */
+    std::string linkage_to_id(const Sails::LinkageData &data);
 
-
- /**
-  * @brief Retrieves the gemmi::Chain object corresponding to a given Glycosite.
-  *
-  * This function retrieves the gemmi::Chain object that represents the chain of the
-  * provided Glycosite within the specified gemmi::Structure.
-  *
-  * @param site The glycosite object containing the model, chain, and residue indices.
-  * @param structure A ptr to a gemmi::Structure object from which the chain is to be retrieved.
-  *
-  * @return The gemmi::Chain object from the specified glycosute.
-  */
- gemmi::Chain get_chain_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
-
- /**
-  * @brief Retrieves the gemmi::Residue corresponding to a given Glycosite.
-  *
-  * This function retrieves the gemmi::Residue object that represents the residue of the
-  * provided Glycosite within the specified gemmi::Structure.
-  *
-  * @param site The glycosite object containing the model, chain, and residue indices.
-  * @param structure A ptr to a structure object from which to retrieve the residue.
-  *
-  * @return The gemmi::Residue from the specified glycosite.
-  */
- gemmi::Residue get_residue_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
-
- /**
- * @brief Retrieves the gemmi::Residue pointer corresponding to a given Glycosite.
- *
- * This function retrieves the gemmi::Residue pointer that represents the residue of the
- * provided Glycosite within the specified gemmi::Structure.
- *
- * @param site The glycosite object containing the model, chain, and residue indices.
- * @param structure A ptr to a structure object from which to retrieve the residue.
- *
- * @return The gemmi::Residue pointer from the specified glycosite.
- */
- gemmi::Residue *get_residue_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
-
- /**
- * @brief Retrieves the gemmi::Chain pointer corresponding to a given Glycosite.
- *
- * This function retrieves the gemmi::Chain pointer that represents the chain of the
- * provided Glycosite within the specified gemmi::Structure.
- *
- * @param site The glycosite object containing the model, chain, and residue indices.
- * @param structure A ptr to a structure object from which to retrieve the chain.
- *
- * @return The gemmi::Chain pointer from the specified glycosite.
- */
- gemmi::Chain *get_chain_ptr_from_glycosite(const Glycosite &site, gemmi::Structure *structure);
-
- /**
-  * @brief Retrieves the gemmi::Atom from the specified glycosite.
-  *
-  * This function retrieves the gemmi::Atom object that represents the atom of the
-  * provided Glycosite within the specified gemmi::Structure.
-  *
-  * @param site The glycosite object containing the model, chain, and residue indices.
-  * @param structure The structure from which to retrieve the atom.
-  *
-  * @return The gemmi::Atom from the specified glycosite.
-  * @throws std::runtime_error if the site has not been initialised from a Mark.
-  */
- gemmi::Atom get_atom_from_glycosite(const Glycosite &site, const gemmi::Structure *structure);
-
- /**
-  * @brief Converts the given LinkageData object into an ID string.
-  *
-  * This function takes a reference to a LinkageData object and converts it into an ID string. The ID string is constructed
-  * by concatenating the donor, donor_number, acceptor_number, and acceptor fields of the LinkageData object.
-  *
-  * @param data The LinkageData object to convert to an ID string.
-  *
-  * @return The ID string representation of the LinkageData object.
-  */
- std::string linkage_to_id(const Sails::LinkageData &data);
-
- /**
-  * @brief Save a vector of gemmi::Residue objects to a specified file path.
-  *
-  * This method takes a vector of gemmi::Residue objects and saves them to the specified file path.
-  * It creates a gemmi::Structure, gemmi::Model, and gemmi::Chain to hold the residues.
-  * The provided residues are appended to the chain, and the chain is added to the model.
-  * Finally, the model is added to the structure.
-  * The structure is then written to the specified file path using the gemmi::write_pdb function.
-  *
-  * @param residues The vector of gemmi::Residue objects to save.
-  * @param path The file path to save the residues to.
-  *
-  * @note The file path must be valid and accessible for writing. If the file already exists, it will be overwritten.
-  */
- void save_residues_to_file(std::vector<gemmi::Residue> residues, const std::string &path);
+    /**
+     * @brief Save a vector of gemmi::Residue objects to a specified file path.
+     *
+     * This method takes a vector of gemmi::Residue objects and saves them to the specified file path.
+     * It creates a gemmi::Structure, gemmi::Model, and gemmi::Chain to hold the residues.
+     * The provided residues are appended to the chain, and the chain is added to the model.
+     * Finally, the model is added to the structure.
+     * The structure is then written to the specified file path using the gemmi::write_pdb function.
+     *
+     * @param residues The vector of gemmi::Residue objects to save.
+     * @param path The file path to save the residues to.
+     *
+     * @note The file path must be valid and accessible for writing. If the file already exists, it will be overwritten.
+     */
+    void save_residues_to_file(std::vector<gemmi::Residue> residues, const std::string &path);
 
 
- /**
-  * @brief Saves a grid to a file in CCP4 format.
-  *
-  * This function saves the given grid to a file in CCP4 format. The grid is defined by the provided
-  * gemmi::Grid<> object and the file path is specified using the std::string path parameter.
-  *
-  * @param grid The grid object to save to file.
-  * @param path The path to the file where the grid will be saved.
-  */
- void save_grid_to_file(const gemmi::Grid<> &grid, const std::string &path);
+    /**
+     * @brief Saves a grid to a file in CCP4 format.
+     *
+     * This function saves the given grid to a file in CCP4 format. The grid is defined by the provided
+     * gemmi::Grid<> object and the file path is specified using the std::string path parameter.
+     *
+     * @param grid The grid object to save to file.
+     * @param path The path to the file where the grid will be saved.
+     */
+    void save_grid_to_file(const gemmi::Grid<> &grid, const std::string &path);
 
- /**
-  * @brief Saves the provided gemmi::Structure object to a file.
-  *
-  * This method saves the provided gemmi::Structure object to a file specified by the given path.
-  *
-  * @param structure The gemmi::Structure object to be saved.
-  * @param path The path of the file where the structure should be saved.
-  */
- void save_structure_to_file(const gemmi::Structure &structure, const std::string &path);
+    /**
+     * @brief Saves the provided gemmi::Structure object to a file.
+     *
+     * This method saves the provided gemmi::Structure object to a file specified by the given path.
+     *
+     * @param structure The gemmi::Structure object to be saved.
+     * @param path The path of the file where the structure should be saved.
+     */
+    void save_structure_to_file(const gemmi::Structure &structure, const std::string &path);
 
 
- /**
-  * @brief Computes the next string will be alphabetically.
-  *
-  * This computes what the string will be if we increment the letter by one. For example this function will return "B"
-  * given the input "A".
-  *
-  * @param input The string to increment.
-  * @return The incremented string.
-  */
- std::string get_next_string(const std::string &input);
+    /**
+     * @brief Computes the next string will be alphabetically.
+     *
+     * This computes what the string will be if we increment the letter by one. For example this function will return "B"
+     * given the input "A".
+     *
+     * @param input The string to increment.
+     * @return The incremented string.
+     */
+    std::string get_next_string(const std::string &input);
 
- /**
-  * @brief Checks if a file exists at the specified path.
-  *
-  * This function checks if a file exists at the specified path.
-  *
-  * @param path The path of the file to check.
-  *
-  * @return true if the file exists, false otherwise.
-  */
- bool file_exists(const std::string &path);
+    /**
+     * @brief Checks if a file exists at the specified path.
+     *
+     * This function checks if a file exists at the specified path.
+     *
+     * @param path The path of the file to check.
+     *
+     * @return true if the file exists, false otherwise.
+     */
+    bool file_exists(const std::string &path);
 
- /**
-  * @brief Splits a string by delimiter
-  *
-  * @param string The string to split
-  * @param delimiter The delimiter to split at
-  *
-  * @return a vector of strings split by the delimiter
-  */
- std::vector<std::string> split(const std::string &string, char delimiter);
-
+    /**
+     * @brief Splits a string by delimiter
+     *
+     * @param string The string to split
+     * @param delimiter The delimiter to split at
+     *
+     * @return a vector of strings split by the delimiter
+     */
+    std::vector<std::string> split(const std::string &string, char delimiter);
 } // namespace Sails::Utils
 
 

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -1,0 +1,32 @@
+//
+// Created by jordan on 05/11/24.
+//
+
+#ifndef SAILS_SAILS_WURCS_H
+#define SAILS_SAILS_WURCS_H
+
+#include "sails-glycan.h"
+
+namespace Sails {
+
+    class WURCS {
+    public:
+        WURCS() = default;
+
+        static std::string generate_wurcs(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+
+        static Sails::Glycan generate_psuedo_glycan(const std::string& wurcs, gemmi::Structure* structure);
+
+    private:
+        static std::string get_unit_count(Sails::Glycan* glycan);
+
+        static std::string get_unique_residue_list(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+
+        static std::string get_wurcs_header() {return "WURCS=2.0";}
+
+        static std::string get_section_delimiter() {return "/";}
+    };
+
+}
+
+#endif //SAILS_SAILS_WURCS_H

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -30,7 +30,7 @@ namespace Sails {
 
         static std::string get_section_delimiter() {return "/";}
 
-        static std::vector<int> calculate_residue_order(const Glycan *glycan, ResidueDatabase &residue_database);
+        static std::vector<int> calculate_residue_order(Glycan *glycan, ResidueDatabase &residue_database);
     };
 
 }

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -6,33 +6,53 @@
 #define SAILS_SAILS_WURCS_H
 
 #include "sails-glycan.h"
+#include <regex>
 
 namespace Sails {
-
     class WURCS {
     public:
         WURCS() = default;
 
-        static std::string generate_wurcs(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+        static std::string generate_wurcs(Glycan *glycan, ResidueDatabase &residue_database);
 
-        static Sails::Glycan generate_psuedo_glycan(const std::string& wurcs, gemmi::Structure* structure);
+        static Glycan generate_pseudo_glycan(const std::string &wurcs, gemmi::Structure *structure,
+                                             LinkageDatabase &linkage_database,
+                                             ResidueDatabase &residue_database);
 
     private:
-        static std::string get_unit_count(Sails::Glycan* glycan);
+        static std::string get_unit_count(Sails::Glycan *glycan);
 
-        static std::string get_unique_residue_list(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+        static std::string get_unique_residue_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database);
 
-        static std::string get_residue_order(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+        static std::string get_residue_order(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database);
 
-        static std::string get_link_list(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+        static std::string get_link_list(Sails::Glycan *glycan, Sails::ResidueDatabase &residue_database);
 
-        static std::string get_wurcs_header() {return "WURCS=2.0";}
+        static std::string get_wurcs_header() { return "WURCS=2.0"; }
 
-        static std::string get_section_delimiter() {return "/";}
+        static std::string get_section_delimiter() { return "/"; }
 
         static std::vector<int> calculate_residue_order(Glycan *glycan, ResidueDatabase &residue_database);
-    };
 
+        // PARSING
+
+        static std::vector<std::string> extract_wurcs_unique_residues(const std::string &wurcs);
+
+        static std::vector<int> extract_wurcs_residue_order(const std::string &wurcs);
+
+        static std::vector<std::string> extract_wurcs_linkage_order(const std::string &wurcs);
+
+        /**
+         * @brief Get key from map using predicate, used to query a linkage or residue database
+         *
+         * @param map The map to get a key from
+         * @param predicate Predicate to search using
+         *
+         * @return optional key
+         */
+        template<typename key, typename value, typename Predicate>
+        static std::optional<key> get_key(const std::map<key, value> &map, Predicate predicate);
+    };
 }
 
 #endif //SAILS_SAILS_WURCS_H

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -22,6 +22,8 @@ namespace Sails {
 
         static std::string get_unique_residue_list(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
 
+        static std::string get_residue_order(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+
         static std::string get_wurcs_header() {return "WURCS=2.0";}
 
         static std::string get_section_delimiter() {return "/";}

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -16,8 +16,8 @@ namespace Sails {
         static std::string generate_wurcs(Glycan *glycan, ResidueDatabase &residue_database);
 
         static Glycan generate_pseudo_glycan(const std::string &wurcs, gemmi::Structure *structure,
-                                             LinkageDatabase &linkage_database,
-                                             ResidueDatabase &residue_database);
+                                             Glycosite &glycosite,
+                                             LinkageDatabase &linkage_database, ResidueDatabase &residue_database);
 
     private:
         static std::string get_unit_count(Sails::Glycan *glycan);
@@ -41,6 +41,17 @@ namespace Sails {
         static std::vector<int> extract_wurcs_residue_order(const std::string &wurcs);
 
         static std::vector<std::string> extract_wurcs_linkage_order(const std::string &wurcs);
+
+        static std::vector<std::string> form_residue_name_order(ResidueDatabase &residue_database,
+                                                               std::vector<std::string> unique_residues,
+                                                               std::vector<int> residue_order);
+
+        static gemmi::Structure generate_pseudo_structure(
+        );
+
+        static void add_linkage_to_pseudo_glycan(std::vector<Sails::Glycosite> &glycosites,
+                                                 Sails::PseudoGlycan &pseudo_glycan,
+                                                 const std::string &linkage_string);
 
         /**
          * @brief Get key from map using predicate, used to query a linkage or residue database

--- a/package/src/include/sails-wurcs.h
+++ b/package/src/include/sails-wurcs.h
@@ -24,9 +24,13 @@ namespace Sails {
 
         static std::string get_residue_order(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
 
+        static std::string get_link_list(Sails::Glycan* glycan, Sails::ResidueDatabase& residue_database);
+
         static std::string get_wurcs_header() {return "WURCS=2.0";}
 
         static std::string get_section_delimiter() {return "/";}
+
+        static std::vector<int> calculate_residue_order(const Glycan *glycan, ResidueDatabase &residue_database);
     };
 
 }

--- a/package/src/sails/__init__.py
+++ b/package/src/sails/__init__.py
@@ -22,7 +22,9 @@ from .sails_module import (
     get_all_snfgs,
     Grid,
     AxisOrder,
-    wurcs,
+    find_all_wurcs,
+    find_wurcs,
+    model_wurcs,
 )
 from .__version__ import __version__
 from .glycosylate import glycosylate_xtal, glycosylate_em, Type
@@ -72,5 +74,7 @@ __all__ = [
     "get_sails_structure",
     "get_sails_mtz",
     "get_sails_map",
-    "wurcs",
+    "find_all_wurcs",
+    "find_wurcs",
+    "model_wurcs",
 ]

--- a/package/src/sails/__init__.py
+++ b/package/src/sails/__init__.py
@@ -22,6 +22,7 @@ from .sails_module import (
     get_all_snfgs,
     Grid,
     AxisOrder,
+    wurcs,
 )
 from .__version__ import __version__
 from .glycosylate import glycosylate_xtal, glycosylate_em, Type
@@ -71,4 +72,5 @@ __all__ = [
     "get_sails_structure",
     "get_sails_mtz",
     "get_sails_map",
+    "wurcs",
 ]

--- a/package/src/sails/data/data.json
+++ b/package/src/sails/data/data.json
@@ -8,6 +8,7 @@
                 2
             ],
             "anomer": "α",
+            "wurcsCode": "a1221m-1a_1-5",
             "donorSets": [],
             "acceptorSets": [
                 {
@@ -30,6 +31,7 @@
                 7
             ],
             "anomer": "α",
+            "wurcsCode": "a1122h-1a_1-5",
             "donorSets": [
                 {
                     "atom3": "O2",
@@ -67,6 +69,7 @@
                 1
             ],
             "anomer": "α",
+            "wurcsCode": "a1122h-1a_1-5",
             "donorSets": [],
             "acceptorSets": [
                 {
@@ -85,6 +88,7 @@
                 3
             ],
             "anomer": "β",
+            "wurcsCode": "a1122h-1b_1-5",
             "donorSets": [
                 {
                     "atom3": "O6",
@@ -117,6 +121,7 @@
                 2
             ],
             "anomer": "β",
+            "wurcsCode": "a2122h-1b_1-5_2*NCC/3=O",
             "donorSets": [
                 {
                     "atom1": "C5",
@@ -154,6 +159,7 @@
                 0
             ],
             "anomer": "",
+            "wurcsCode": "",
             "donorSets": [
                 {
                     "atom1": "CB",
@@ -172,6 +178,7 @@
                 0
             ],
             "anomer": "",
+            "wurcsCode": "",
             "donorSets": [
                 {
                     "atom1": "CD2",
@@ -190,6 +197,7 @@
                 0
             ],
             "anomer": "",
+            "wurcsCode": "",
             "donorSets": [
                 {
                     "atom1": "CA",
@@ -208,6 +216,7 @@
                 0
             ],
             "anomer": "",
+            "wurcsCode": "",
             "donorSets": [
                 {
                     "atom1": "CA",

--- a/package/src/sails/data/data.json
+++ b/package/src/sails/data/data.json
@@ -8,7 +8,7 @@
                 7
             ],
             "anomer": "α",
-            "wurcs": "",
+            "wurcsCode": "",
             "special": false,
             "donorSets": [],
             "acceptorSets": [
@@ -28,7 +28,7 @@
                 6
             ],
             "anomer": "β",
-            "wurcs": "",
+            "wurcsCode": "",
             "special": false,
             "donorSets": [
                 {

--- a/package/src/sails/wurcs.py
+++ b/package/src/sails/wurcs.py
@@ -1,0 +1,26 @@
+import argparse
+from .__version__ import __version__
+import importlib
+from sails import wurcs, interface
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("-modelin", help="Path to input model", type=str, required=True)
+    parser.add_argument("-chain", help="Name of target chain", type=str, required=True)
+    parser.add_argument(
+        "-res", help="Name of target residue (protein)", type=str, required=True
+    )
+
+    return parser.parse_args()
+
+
+def run():
+    args = parse_args()
+
+    sails_structure = interface.get_sails_structure(args.modelin)
+    resource = importlib.resources.files("sails").joinpath("data")
+
+    wurcs(sails_structure, args.chain, args.res, str(resource))

--- a/package/src/sails/wurcs.py
+++ b/package/src/sails/wurcs.py
@@ -1,16 +1,64 @@
 import argparse
 from .__version__ import __version__
 import importlib
-from sails import wurcs, interface
+from sails import find_all_wurcs, find_wurcs, model_wurcs, interface
+import json
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="mode", required=True)
 
     parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument("-modelin", help="Path to input model", type=str, required=True)
-    parser.add_argument("-chain", help="Name of target chain", type=str, required=True)
-    parser.add_argument(
+    parent = argparse.ArgumentParser(add_help=False)
+    group = parent.add_argument_group("Required arguments for all modes")
+    # group.add_argument("-v", action=argparse.BooleanOptionalAction, default=False)
+    group.add_argument("-modelin", type=str, required=True)
+
+    formatter = argparse.ArgumentDefaultsHelpFormatter
+    find_parser = subparsers.add_parser(
+        "find", parents=[parent], formatter_class=formatter
+    )
+    find_parser.add_argument(
+        "-all",
+        help="Find WURCS identifiers for all glycans",
+        action=argparse.BooleanOptionalAction,
+        required=False,
+    )
+    find_parser.add_argument(
+        "-chain", help="Name of target chain", type=str, required=False
+    )
+    find_parser.add_argument(
+        "-res", help="Name of target residue (protein)", type=str, required=False
+    )
+    find_parser.add_argument(
+        "-jsonout",
+        help="Path to output json file",
+        type=str,
+        default="wurcs.json",
+        required=False,
+    )
+
+    model_parser = subparsers.add_parser(
+        "model", parents=[parent], formatter_class=formatter
+    )
+    model_parser.add_argument(
+        "-modelout",
+        help="Path to the output model",
+        type=str,
+        required=False,
+        default="sails-model-out.cif",
+    )
+    model_parser.add_argument(
+        "-wurcs",
+        help="WURCS code to add to specified chain and residue",
+        type=str,
+        required=True,
+    )
+    model_parser.add_argument(
+        "-chain", help="Name of target chain", type=str, required=True
+    )
+    model_parser.add_argument(
         "-res", help="Name of target residue (protein)", type=str, required=True
     )
 
@@ -23,4 +71,16 @@ def run():
     sails_structure = interface.get_sails_structure(args.modelin)
     resource = importlib.resources.files("sails").joinpath("data")
 
-    wurcs(sails_structure, args.chain, args.res, str(resource))
+    if args.mode == "find":
+        if args.all:
+            wurcs = find_all_wurcs(sails_structure, str(resource))
+        else:
+            wurcs = find_wurcs(sails_structure, args.chain, args.res, str(resource))
+        with open(args.jsonout, "w", encoding="UTF-8") as json_file:
+            json.dump(wurcs, json_file, indent=4)
+    else:
+        result = model_wurcs(
+            sails_structure, args.wurcs, args.chain, args.res, str(resource)
+        )
+        structure = interface.extract_sails_structure(result)
+        structure.make_mmcif_block().write_file(args.modelout)


### PR DESCRIPTION
## Description

* Adds `sails-wurcs` command line argument to interface with WURCS codes
* `sails-wurcs find` will calculate the WURCS code for a given glycan
* `sails-wurcs model`  will model a given WURCS code onto a given residue